### PR TITLE
chore: update action cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: 17
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
### What does this PR do?
Updates to the latest actions cache.

### Where should the reviewer start?

Check that actions/cache@v4 works for you.

### Why is it needed?

Per [GitHub](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/) versions 1 and 2 will go offline 01 FEB 2025.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.